### PR TITLE
Changes ‘data_gen’ to ‘page_gen’; fixes spacing.

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -23,12 +23,12 @@ h1. Usage
 The specification in config.yml is as follows:
 
 <pre>
- data_gen:
- - data: <<name of the data>>
-   template: <<name of the template to use to generate the page>>
-   name: <<field used to generate the filename>>
-   dir: <<directory in which files are to be generated>> 
- - ... 
+page_gen:
+- data: <<name of the data>>
+  template: <<name of the template to use to generate the page>>
+  name: <<field used to generate the filename>>
+  dir: <<directory in which files are to be generated>>
+- ...
 </pre>
 
 where:

--- a/README.textile
+++ b/README.textile
@@ -24,11 +24,11 @@ The specification in config.yml is as follows:
 
 <pre>
 page_gen:
-- data: <<name of the data>>
-  template: <<name of the template to use to generate the page>>
-  name: <<field used to generate the filename>>
-  dir: <<directory in which files are to be generated>>
-- ...
+  - data: <<name of the data>>
+    template: <<name of the template to use to generate the page>>
+    name: <<field used to generate the filename>>
+    dir: <<directory in which files are to be generated>>
+  - ...
 </pre>
 
 where:


### PR DESCRIPTION
Fixed too typos that temporarily vexed me while setting this up for the first time.

(1) I change `data_gen` to `page_gen`, which is consistent with both your later example in README as well as the plugin code itself.
(2) Removed the unnecessary leading space in that same pre-formatted code block, which likewise caused my `_config.yml` file to hang on build.