### PR TITLE
Accept JSON or YAML Files

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -1,6 +1,6 @@
 h1. Jekyll Data Pages Generator
 
-Jekyll allows data to be specified in YAML format in the @_data@ dir.
+Jekyll allows data to be specified in YAML or JSON format in the @_data@ dir.
 
 If the data is an array, it is straightforward to build an index page, containing all records, using a Liquid for loop.  In some occasions, however, you also want to generate one page per record.  Consider, e.g., a list of team members, for which you want to generate an individual page for each member.
 
@@ -59,6 +59,24 @@ h1. Example
   bio: another long bio
 - name: aaron ciaghi
   bio: another very long bio
+</pre>
+
+Alternatively, you could have @member.json@ file stored in the @_data@ directory with the following content and the example would work the same:
+<pre>
+[
+  {
+    "name": "adolfo villafiorita",
+    "bio": "long bio goes here"
+  },
+  {
+    "name": "pietro molini",
+    "bio": "another long bio"
+  },
+  {
+    "name": "aaron ciaghi",
+    "bio": "another very long bio"
+  }
+]
 </pre>
 
 2. There is a @profile.html@ file stored in the @_layouts@ directory:

--- a/data_page_generator.rb
+++ b/data_page_generator.rb
@@ -35,13 +35,12 @@ module Jekyll
       if data
         data.each do |data_spec|
           # todo: check input data correctness
-          data_file = '_data/' + data_spec['data'] + ".yml"
           template = data_spec['template'] || data_spec['data']
           name = data_spec['name']
           dir = data_spec['dir'] || data_spec['data']
           
-          if File.exists?(data_file) and site.layouts.key? template
-            records =  YAML.load(File.read(data_file))
+          if site.layouts.key? template
+            records =  site.data[data_spec['data']]
             records.each do |record|
               site.pages << DataPage.new(site, site.source, dir, record, name, template)
             end

--- a/example/_config.yml
+++ b/example/_config.yml
@@ -3,3 +3,7 @@ page_gen:
     template: 'profile'
     name: 'name'
     dir: 'people'
+  - data: 'pet'
+    template: 'profile'
+    name: 'name'
+    dir: 'pets'

--- a/example/_data/pet.json
+++ b/example/_data/pet.json
@@ -1,0 +1,10 @@
+[
+  {
+    "name": "Ben Salinas",
+    "bio": "long bio goes here"
+  },
+  {
+    "name": "Fido The Dog",
+    "bio": "another long bio"
+  }
+]

--- a/example/index.textile
+++ b/example/index.textile
@@ -1,5 +1,11 @@
 ---
 ---
+<h1>People (generated from YAML)</h1>
 {% for person in site.data.member %}
 * "{{person.name}}":{{ person.name | datapage_url: 'people' }}
+{% endfor %}
+
+<h1>Pets (generated from JSON)</h1>
+{% for pet in site.data.pet %}
+* "{{pet.name}}":{{ pet.name | datapage_url: 'pets' }}
 {% endfor %}


### PR DESCRIPTION
I updated the generator to use the built in `site.data` variable that Jekyll provides. This allows you to use either a YAML or JSON file to generate the static pages.

Let me know what you think!