### PR TITLE
Removing `index.html` from generated datapage links

### DIFF
--- a/data_page_generator.rb
+++ b/data_page_generator.rb
@@ -116,12 +116,8 @@ module Jekyll
     # Thus, if you use the `extension` feature of this plugin, you
     # need to generate the links by hand
     def datapage_url(input, dir)
-      @gen_dir = Jekyll.configuration({})['page_gen-dirs']
-      if @gen_dir then
-        dir + "/" + sanitize_filename(input) + "/index.html"
-      else
-        dir + "/" + sanitize_filename(input) + ".html"
-      end
+      extension = Jekyll.configuration({})['page_gen-dirs'] ? '/' : '.html'
+      "#{dir}/#{sanitize_filename(input)}#{extension}"
     end
   end
 


### PR DESCRIPTION
Hello. This PR removes the `index.html` from the end of links created with the `datapage_url:` liquid filter when the `page_gen-dirs` config option is specified. This suffix is unnecessary with most web servers, and more closely follows Jekyll's method for generating permalinks.