### PR TITLE
Document index_files parameter

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -24,7 +24,8 @@ The specification in config.yml is as follows:
 
 <pre>
 page_gen:
-  - data: <<name of the data>>
+  - index_files: <<true or false>
+    data: <<name of the data>>
     template: <<name of the template to use to generate the page>>
     name: <<field used to generate the filename>>
     dir: <<directory in which files are to be generated>>
@@ -35,6 +36,7 @@ page_gen:
 
 where:
 
+- @index_files@ := specifies if we want to generate named folders (true) or not (false)
 - @data@ := is the name of the file to read
 - @name@ := is the name of a field which contains a unique identifier that can  be used to generate a filename
 - @template@ := is the name of a template to generate the pages (it defaults to the value of @data@ + ".html"). *Optional:* if not set, the generator uses the value of the @data@ field
@@ -49,7 +51,7 @@ A liquid tag is also made available to generate a link to a given page.  For ins
 <pre>
    {{ page_name | datapage_url: dir }}
 </pre>
- 
+
 generates a link to @page_name@ in @dir@.
 
 h1. Named Folders

--- a/data_page_generator.rb
+++ b/data_page_generator.rb
@@ -39,13 +39,8 @@ module Jekyll
       # the value of these variables changes according to whether we
       # want to generate named folders or not
       filename = sanitize_filename(data[name]).to_s
-      if index_files
-        @dir = dir + (index_files ? "/" + filename + "/" : "")
-        @name =  "index" + "." + extension.to_s
-      else
-        @dir = dir
-        @name = filename + "." + extension.to_s
-      end
+      @dir = dir + (index_files ? "/" + filename + "/" : "")
+      @name = (index_files ? "index" : filename) + "." + extension.to_s
 
       self.process(@name)
       self.read_yaml(File.join(base, '_layouts'), template + ".html")
@@ -125,4 +120,3 @@ module Jekyll
 end
 
 Liquid::Template.register_filter(Jekyll::DataPageLinkGenerator)
-


### PR DESCRIPTION
I've just noticed that `index_files` configuration parameter is not documented in `README.textile`. Also, this `if ... else ...` seems unnecessary, but it's the first time I see Ruby code (I've checked it works).