### PR TITLE
Add name expr

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ where:
 :   is the name of a field in data which contains a unique identifier
     that can be used to generate a filename
 
+`name_expr`
+:   is an optional Ruby expression used to generate a filename.  The
+expression can reference fields of the data being read using the `record`
+hash(e.g., `record['first_name'] + "_" + record['last_name']`)
+**Optional:** if set, this overrides `name`
+
 `template`
 :   is the name of a template to generate the pages (it defaults to the
     value of `data` + ".html"). **Optional:** if not set, the generator
@@ -297,13 +303,36 @@ limited number of values, since one needs to explicitly specify in
 `_config.yml` conditions and target directories.
 
 
+Generating Filename with an Expression
+=============
 
+You can generate filenames with an expression, by replacing `name` with `name_expr`.
+For example, if you have data in a .yml file that looks like this:
+```
+    - first_name: adolfo
+      last_name: villafiorita
+      bio: long bio goes here
+    - first_name: pietro
+      last_name: molini
+      bio: another long bio
+    - first_name: aaron
+      last_name: ciaghi
+      bio: another very long bio
+```
+
+Your `_config.yml` could contain the following:
+
+    page_gen:
+      - data: 'members'
+        template: 'profile'
+        name_expr: record['first_name'] + "_" + record['last_name']
+        dir: 'people'
 
 
 Compatibility
 =============
 
-Run with Jekyll 3.1.6 and Jekyll 3.6.2, it should also work with
+Run with Jekyll 3.1.6, 3.6.2 and 3.8.5, it should also work with
 previous versions of Jekyll. Try with the included example and open an
 issue if you find any compatibility issue.
 

--- a/data_page_generator.rb
+++ b/data_page_generator.rb
@@ -28,32 +28,50 @@ module Jekyll
     # - `dir` is the default output directory
     # - `data` is the data defined in `_data.yml` of the record for which we are generating a page
     # - `name` is the key in `data` which determines the output filename
+    # - `name_expr` is an expression for generating the output filename
     # - `template` is the name of the template for generating the page
     # - `extension` is the extension for the generated file
-    def initialize(site, base, index_files, dir, data, name, template, extension)
+    def initialize(site, base, index_files, dir, data, name, name_expr, template, extension)
       @site = site
       @base = base
 
       # @dir is the directory where we want to output the page
       # @name is the name of the page to generate
+      # @name_expr is an expression for generating the name of the page
       #
       # the value of these variables changes according to whether we
       # want to generate named folders or not
-      if data[name] == nil
-        puts "error (datapage_gen). empty value for field '#{name}' in record #{data}"
+      if name_expr
+        record = data
+        raw_filename = eval(name_expr)
+        if raw_filename == nil
+          puts "error (datapage_gen). name_expr '#{name}' generated an empty value in record #{data}"
+          return
+        end
       else
-        filename = sanitize_filename(data[name]).to_s
-
-        @dir = dir + (index_files ? "/" + filename + "/" : "")
-        @name = (index_files ? "index" : filename) + "." + extension.to_s
-
-        self.process(@name)
-        self.read_yaml(File.join(base, '_layouts'), template + ".html")
-        self.data['title'] = data[name]
-        # add all the information defined in _data for the current record to the
-        # current page (so that we can access it with liquid tags)
-        self.data.merge!(data)
+        raw_filename = data[name]
+        if raw_filename == nil
+          puts "error (datapage_gen). empty value for field '#{name}' in record #{data}"
+          return
+        end
       end
+
+      filename = sanitize_filename(raw_filename).to_s
+
+      @dir = dir + (index_files ? "/" + filename + "/" : "")
+      @name = (index_files ? "index" : filename) + "." + extension.to_s
+
+      self.process(@name)
+      self.read_yaml(File.join(base, '_layouts'), template + ".html")
+      self.data['title'] = raw_filename
+      # add all the information defined in _data for the current record to the
+      # current page (so that we can access it with liquid tags)
+
+      if data.key?('name')
+        data['_name'] = data['name']
+      end
+
+      self.data.merge!(data)
     end
   end
 
@@ -78,6 +96,7 @@ module Jekyll
           index_files_for_this_data = data_spec['index_files'] != nil ? data_spec['index_files'] : index_files
           template = data_spec['template'] || data_spec['data']
           name = data_spec['name']
+          name_expr = data_spec['name_expr']
           dir = data_spec['dir'] || data_spec['data']
           extension = data_spec['extension'] || "html"
 
@@ -100,7 +119,7 @@ module Jekyll
             records = records.select { |record| eval(data_spec['filter_condition']) } if data_spec['filter_condition']
 
             records.each do |record|
-              site.pages << DataPage.new(site, site.source, index_files_for_this_data, dir, record, name, template, extension)
+              site.pages << DataPage.new(site, site.source, index_files_for_this_data, dir, record, name, name_expr, template, extension)
             end
           else
             puts "error (datapage_gen). could not find template #{template}" if not site.layouts.key? template

--- a/data_page_generator.rb
+++ b/data_page_generator.rb
@@ -45,7 +45,7 @@ module Jekyll
         record = data
         raw_filename = eval(name_expr)
         if raw_filename == nil
-          puts "error (datapage_gen). name_expr '#{name}' generated an empty value in record #{data}"
+          puts "error (datapage_gen). name_expr '#{name_expr}' generated an empty value in record #{data}"
           return
         end
       else


### PR DESCRIPTION
Thank you so much for this awesome plugin!

This Pull Request adds a `name_expr` option to your config, so people can programmatically generate filenames based on a Ruby expression.  We are using this with http://geography2050.org, so we can create filenames based on the combination of both the first_name and last_name fields in a CSV.

I also added in some code so that if the data includes a `name` key, people can still access that key-value through `page._name` in a layout.