### PR TITLE
added hash detection and conversion of values to array

### DIFF
--- a/data_page_generator.rb
+++ b/data_page_generator.rb
@@ -111,6 +111,9 @@ module Jekyll
                 records = records[level]
               end
             end
+            if (records.kind_of?(Hash))
+              records = records.values
+            end
 
             # apply filtering conditions:
             # - filter requires the name of a boolean field


### PR DESCRIPTION
Not sure if this is a caused by Jekyll 4.0 or not, but when using both CSV and YML files in the _data directory, I ran into an issue where the CSV were imported fine, but YML files were failing due to the  Array value returning as the index and not the Hash Value.  Added this little ditty to bat cleanup and all worked well.  Thanks for sharing this plugin, it was EXACTLY what I needed/wanted!