### PR TITLE
Adds support for files without an extension

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -2,6 +2,12 @@
 #+AUTHOR: Adolfo Villafiorita
 #+STARTUP: showall
 
+* Version 1.4.0
+
+** New Functions and Fixes
+
+- Generate files without an extension (see #131)
+
 * Version 1.3.0
 
 ** New Functions and Fixes

--- a/README.org
+++ b/README.org
@@ -69,7 +69,7 @@ The specification in =config.yml= looks like:
     name_expr: [a Ruby expression to generate the filename (alternative to name)]
     title: [field used to generate the page title]
     title_expr: [a Ruby expression to generate the filename (alternative to title)]
-    extension: [extension used to generate the filename]
+    extension: [extension used to generate the filename.]
     filter: [property to filter data records by]
     filter_condition: [a Ruby expression to filter data]
     page_data_prefix: [prefix used to name variables]
@@ -126,6 +126,7 @@ Each entry in ~page_gen~ can (in some cases must) contain the following fields:
 
 - ~extension~ is the extension of the generated files. 
   /Optional: if not specified, the generator uses ~html~ extension./
+  If set to false, the file will be generated without an extension
 
 - ~page_data_prefix~ is the prefix used to output the page data.  Data
   read from each record is made available in the page so that it can

--- a/lib/jekyll-datapage-generator.rb
+++ b/lib/jekyll-datapage-generator.rb
@@ -91,7 +91,11 @@ module Jekyll
       filename = sanitize_filename(raw_filename).to_s
 
       @dir = dir + (index_files ? "/" + filename + "/" : "")
-      @name = (index_files ? "index" : filename) + "." + extension.to_s
+      @name = (index_files ? "index" : filename)
+      
+      if extension
+        @name += "." + extension.to_s
+      end
 
       self.process(@name)
 
@@ -147,9 +151,12 @@ module Jekyll
           title            = data_spec['title']
           title_expr       = data_spec['title_expr']
           dir              = data_spec['dir'] || data_spec['data']
-          extension        = data_spec['extension'] || "html"
           page_data_prefix = data_spec['page_data_prefix']
           debug            = data_spec['debug']
+
+          unless data_spec.key? 'extension'
+            data_spec['extension'] = 'html'
+          end
           
           if not site.layouts.key? template
             puts "error (datapage-gen). could not find template #{template}. Skipping dataset #{name}."
@@ -178,7 +185,7 @@ module Jekyll
             # we now have the list of all records for which we want to generate individual pages
             # iterate and call the constructor
             records.each do |record|
-              site.pages << DataPage.new(site, site.source, index_files_for_this_data, dir, page_data_prefix, record, name, name_expr, title, title_expr, template, extension, debug)
+              site.pages << DataPage.new(site, site.source, index_files_for_this_data, dir, page_data_prefix, record, name, name_expr, title, title_expr, template, data_spec['extension'], debug)
             end
           end
         end

--- a/test_cases/issue-131/_config.yml
+++ b/test_cases/issue-131/_config.yml
@@ -1,0 +1,8 @@
+page_gen-dirs: false
+
+page_gen:
+  - data: 'books'
+    template: 'book'
+    name: id
+    dir: books
+    extension: false

--- a/test_cases/issue-131/_data/books.yml
+++ b/test_cases/issue-131/_data/books.yml
@@ -1,0 +1,88 @@
+- author: Harper Lee
+  title: To Kill a Mockingbird
+  read: no
+  rating: 4.26
+  year: 1960
+  id: BOOK-99-1
+- author: George Orwell
+  title: 1984
+  read: yes
+  rating: 4.15
+  year: 1949
+  id: BOOK-99-2
+- author: F. Scott Fitzgerald
+  title: The Great Gatsby
+  read: no
+  rating: 3.89
+  year: 1925
+  id: BOOK-99-3
+- title: "Harry Potter and the Sorcerer's Stone (Harry Potter, #1)"
+  author: J.K. Rowling 
+  read: no
+  rating: 4.45
+  id: BOOK-99-4
+  year: 1998
+- author: George Orwell
+  title: Animal Farm
+  read: yes
+  rating: 3.88
+  year: 1945
+  id: BOOK-99-5
+- author: J.R.R. Tolkien
+  title: The Hobbit
+  read: no
+  rating: 4.25
+  year: 1937
+  id: BOOK-99-6
+- author: Anne Frank
+  title: The Diary of a Young Girl
+  rating: 4.10
+  read: no
+  id: BOOK-99-7
+- author: J.D. Salinger
+  title: The Catcher in the Rye
+  read: no
+  rating: 3.79
+  year: 1951
+  id: BOOK-99-8
+- author: Ray Bradbury
+  title: Fahrenheit 451
+  read: yes
+  rating: 3.98
+  year: 1953
+  id: BOOK-99-9
+- author: John Steinbeck
+  title: The Grapes of Wrath
+  read: yes
+  rating: 3.93
+  year: 1939
+  id: BOOK-99-10
+- author: C.S. Lewis
+  title: The Lion, the Witch, and the Wardrobe (Chronicles of Narnia, \#1)
+  read: no
+  rating: 4.19
+  year: 
+  id: BOOK-99-11
+- author: Gabriel García Márquez
+  title: One Hundred Years of Solitude
+  read: yes
+  rating: 4.04
+  year: 1967
+  id: BOOK-99-12
+- author: Aldous Huxley
+  title: Brave New World
+  read: yes
+  rating: 3.97
+  id: BOOK-99-13
+- author: Antoine de Saint-Exupéry
+  title: The Little Prince
+  read: yes
+  rating: 4.29
+  year: 1943
+  id: BOOK-99-14
+- author: John Steinbeck 
+  title:  Of Mice and Men
+  rating: 3.84
+  read: yes
+  year: 1937
+  id: BOOK-99-16

--- a/test_cases/issue-131/_layouts/book.html
+++ b/test_cases/issue-131/_layouts/book.html
@@ -1,0 +1,11 @@
+<h1>{{page.name}}</h1>
+
+<ul>
+    <li><tt>page.author</tt>: {{page.author}}</li>
+    <li><tt>page.title</tt>: {{page.title}}</li>
+    <li><tt>page.year</tt>: {{page.year}}</li>
+    <li><tt>page.rating</tt>: {{page.rating}}</li>
+    <li><tt>page.id</tt>: {{page.id}}</li>
+</ul>
+
+Additionally, you also have access to <tt>page.name</tt>, which is the filename of the page, that is: {{page.name}}.

--- a/test_cases/issue-131/_plugins/jekyll-datapage-generator.rb
+++ b/test_cases/issue-131/_plugins/jekyll-datapage-generator.rb
@@ -1,0 +1,1 @@
+../../../lib/jekyll-datapage-generator.rb


### PR DESCRIPTION
Setting extension: false now generates
files without any extension

Fixes https://github.com/avillafiorita/jekyll-datapage_gen/issues/131